### PR TITLE
Fix: exclude xml declaration when serialize request envelope body & Add SOAPAction http header setup API

### DIFF
--- a/SimpleSOAPClient/src/SimpleSOAPClient/Helpers/XmlHelpers.cs
+++ b/SimpleSOAPClient/src/SimpleSOAPClient/Helpers/XmlHelpers.cs
@@ -54,9 +54,17 @@ namespace SimpleSOAPClient.Helpers
             {
                 new XmlSerializer(item.GetType())
                     .Serialize(textWriter, item, EmptyXmlSerializerNamespaces);
-                var result = textWriter.ToString();
 
-                return result;
+                //exclude xml declaration if present (<?xml... ?>)
+                var rvsb = textWriter.GetStringBuilder();
+                if (rvsb.Length > 5 && rvsb[0] == '<' && rvsb[1] == '?')
+                {
+                    for (int i = 2; i < rvsb.Length; ++i)
+                    {
+                        if (rvsb[i] == '<') return rvsb.ToString(i, rvsb.Length - i);
+                    }
+                }
+                return rvsb.ToString();
             }
         }
 

--- a/SimpleSOAPClient/src/SimpleSOAPClient/ISoapClient.cs
+++ b/SimpleSOAPClient/src/SimpleSOAPClient/ISoapClient.cs
@@ -66,8 +66,31 @@ namespace SimpleSOAPClient
         /// Sends the given <see cref="SoapEnvelope"/> into the specified url.
         /// </summary>
         /// <param name="url">The url that will receive the request</param>
+        /// <param name="soapAction">SOAPAction http header value</param>
+        /// <param name="requestEnvelope">The <see cref="SoapEnvelope"/> to be sent</param>
+        /// <param name="ct">The cancellation token</param>
+        /// <returns>A task to be awaited for the result</returns>
+        Task<SoapEnvelope> SendAsync(
+            string url, string soapAction, 
+            SoapEnvelope requestEnvelope, CancellationToken ct = default(CancellationToken));
+
+        /// <summary>
+        /// Sends the given <see cref="SoapEnvelope"/> into the specified url.
+        /// </summary>
+        /// <param name="url">The url that will receive the request</param>
         /// <param name="requestEnvelope">The <see cref="SoapEnvelope"/> to be sent</param>
         /// <returns>The resulting <see cref="SoapEnvelope"/></returns>
         SoapEnvelope Send(string url, SoapEnvelope requestEnvelope);
+
+
+        /// <summary>
+        /// Sends the given <see cref="SoapEnvelope"/> into the specified url with specified SOAPAction http header value.
+        /// </summary>
+        /// <param name="url">The url that will receive the request</param>
+        /// <param name="soapAction">SOAPAction http header value</param>
+        /// <param name="requestEnvelope">The <see cref="SoapEnvelope"/> to be sent</param>
+        /// <returns>The resulting <see cref="SoapEnvelope"/></returns>
+        SoapEnvelope Send(string url, string soapAction, SoapEnvelope requestEnvelope);
+
     }
 }

--- a/SimpleSOAPClient/src/SimpleSOAPClient/Properties/AssemblyInfo.cs
+++ b/SimpleSOAPClient/src/SimpleSOAPClient/Properties/AssemblyInfo.cs
@@ -45,5 +45,5 @@ using System.Runtime.InteropServices;
 
 [assembly: CLSCompliant(true)]
 
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1")]

--- a/SimpleSOAPClient/src/SimpleSOAPClient/SoapClient.cs
+++ b/SimpleSOAPClient/src/SimpleSOAPClient/SoapClient.cs
@@ -109,12 +109,14 @@ namespace SimpleSOAPClient
         /// Sends the given <see cref="SoapEnvelope"/> into the specified url.
         /// </summary>
         /// <param name="url">The url that will receive the request</param>
+        /// <param name="soapAction">SOAPAction http header value</param>
         /// <param name="requestEnvelope">The <see cref="SoapEnvelope"/> to be sent</param>
         /// <param name="ct">The cancellation token</param>
         /// <returns>A task to be awaited for the result</returns>
 #if NET40
         public virtual Task<SoapEnvelope> SendAsync(
-            string url, SoapEnvelope requestEnvelope, CancellationToken ct = default(CancellationToken))
+            string url, string soapAction, 
+            SoapEnvelope requestEnvelope, CancellationToken ct = default(CancellationToken))
         {
             if (RequestEnvelopeHandler != null)
                 requestEnvelope = RequestEnvelopeHandler(url, requestEnvelope);
@@ -125,9 +127,16 @@ namespace SimpleSOAPClient
 
             var cts = new TaskCompletionSource<SoapEnvelope>();
 
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.Content = new StringContent(requestXml, Encoding.UTF8, "text/xml");
+            if (!string.IsNullOrEmpty(soapAction))
+            {
+                request.Headers.Remove("SOAPAction");
+                request.Headers.Add("SOAPAction", soapAction);
+            }
+
             HttpClient
-                .PostAsync(
-                    url, new StringContent(requestXml, Encoding.UTF8, "text/xml"), ct)
+                .SendAsync(request, ct)
                 .ContinueWith(t01 =>
                 {
                     if (t01.IsFaulted)
@@ -171,7 +180,8 @@ namespace SimpleSOAPClient
         }
 #else
         public virtual async Task<SoapEnvelope> SendAsync(
-            string url, SoapEnvelope requestEnvelope, CancellationToken ct = default(CancellationToken))
+            string url, string soapAction, 
+            SoapEnvelope requestEnvelope, CancellationToken ct = default(CancellationToken))
         {
             if (RequestEnvelopeHandler != null)
                 requestEnvelope = RequestEnvelopeHandler(url, requestEnvelope);
@@ -180,9 +190,15 @@ namespace SimpleSOAPClient
             if (RequestRawHandler != null)
                 requestXml = RequestRawHandler(url, requestXml);
 
-            var result =
-                await HttpClient.PostAsync(
-                    url, new StringContent(requestXml, Encoding.UTF8, "text/xml"), ct);
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.Content = new StringContent(requestXml, Encoding.UTF8, "text/xml");
+            if (!string.IsNullOrEmpty(soapAction))
+            {
+                request.Headers.Remove("SOAPAction");
+                request.Headers.Add("SOAPAction", soapAction);
+            }
+
+            var result = await HttpClient.SendAsync(request, ct);
 
             var responseXml = await result.Content.ReadAsStringAsync();
             if (ResponseRawHandler != null)
@@ -195,7 +211,14 @@ namespace SimpleSOAPClient
 
             return responseEnvelope;
         }
+
 #endif
+
+        public virtual Task<SoapEnvelope> SendAsync(
+            string url, SoapEnvelope requestEnvelope, CancellationToken ct = default(CancellationToken))
+        {
+            return SendAsync(url, null, requestEnvelope, ct);
+        }
 
         /// <summary>
         /// Sends the given <see cref="SoapEnvelope"/> into the specified url.
@@ -205,9 +228,20 @@ namespace SimpleSOAPClient
         /// <returns>The resulting <see cref="SoapEnvelope"/></returns>
         public virtual SoapEnvelope Send(string url, SoapEnvelope requestEnvelope)
         {
-            return SendAsync(url, requestEnvelope).Result;
+            return Send(url, null, requestEnvelope);
         }
 
+        /// <summary>
+        /// Sends the given <see cref="SoapEnvelope"/> into the specified url.
+        /// </summary>
+        /// <param name="url">The url that will receive the request</param>
+        /// <param name="soapAction">SOAPAction http header value</param>
+        /// <param name="requestEnvelope">The <see cref="SoapEnvelope"/> to be sent</param>
+        /// <returns>The resulting <see cref="SoapEnvelope"/></returns>
+        public virtual SoapEnvelope Send(string url, string soapAction, SoapEnvelope requestEnvelope)
+        {
+            return SendAsync(url, requestEnvelope).Result;
+        }
         #endregion
 
         #region Implementation of IDisposable

--- a/SimpleSOAPClient/src/SimpleSOAPClient/project.json
+++ b/SimpleSOAPClient/src/SimpleSOAPClient/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "SimpleSOAPClient",
   "description": "Lightweight SOAP client for invoking HTTP SOAP endpoints",
   "authors": [ "João Simões" ],


### PR DESCRIPTION
Fix: exclude xml declaration when serialize request envelope body;
Add: Support 'SOAPAction' http header setup in SoapClient::Send api