### PR TITLE
Add support for receiving multipart responses with attachments

### DIFF
--- a/src/SimpleSOAPClient/Exceptions/SoapAttachmentDeserializationException.cs
+++ b/src/SimpleSOAPClient/Exceptions/SoapAttachmentDeserializationException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace SimpleSOAPClient.Exceptions
+{
+    public class SoapAttachmentDeserializationException : SoapClientException
+    {
+        /// <inheritdoc />
+        public SoapAttachmentDeserializationException(string message) : base(message)
+        {
+        }
+
+        /// <inheritdoc />
+        public SoapAttachmentDeserializationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/SimpleSOAPClient/Exceptions/SoapAttachmentDeserializationException.cs
+++ b/src/SimpleSOAPClient/Exceptions/SoapAttachmentDeserializationException.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace SimpleSOAPClient.Exceptions
 {
+    /// <summary>
+    /// Thrown when a problem is encountered deserializing MTOM attachments.
+    /// </summary>
     public class SoapAttachmentDeserializationException : SoapClientException
     {
         /// <inheritdoc />

--- a/src/SimpleSOAPClient/Models/SoapEnvelope.cs
+++ b/src/SimpleSOAPClient/Models/SoapEnvelope.cs
@@ -21,6 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #endregion
+
+using System.Collections.Generic;
+using System.Net.Http;
+
 namespace SimpleSOAPClient.Models
 {
     using System.Xml.Serialization;
@@ -42,6 +46,13 @@ namespace SimpleSOAPClient.Models
         /// </summary>
         [XmlElement("Body")]
         public SoapEnvelopeBody Body { get; set; }
+        
+        /// <summary>
+        /// MTOM attachments of the SOAP message.
+        /// See https://www.w3.org/TR/soap12-mtom.
+        /// </summary>
+        [XmlIgnore]
+        public IDictionary<string, HttpContent> Attachments { get; set; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="SoapEnvelope"/>

--- a/src/SimpleSOAPClient/Models/Xop/Include.cs
+++ b/src/SimpleSOAPClient/Models/Xop/Include.cs
@@ -1,13 +1,20 @@
+using System;
 using System.Xml.Serialization;
 
 namespace SimpleSOAPClient.Models.Xop
 {
+    
     /// <summary>
     /// A reference to an attachment to the SoapEnvelope; see https://www.w3.org/TR/soap12-mtom/
     /// </summary>
-    [XmlType(Namespace = "http://www.w3.org/2004/08/xop/include")]
+    [XmlType(Namespace = Namespace)]
     public class Include
     {
+        /// <summary>
+        /// The W3 namespace for XOP Include
+        /// </summary>
+        public const string Namespace = "http://www.w3.org/2004/08/xop/include";
+        
         /// <summary>
         /// The Content Id of the associated attachment.
         /// </summary>
@@ -18,7 +25,18 @@ namespace SimpleSOAPClient.Models.Xop
         /// Helper method to generate the href attribute when serialized to XML.
         /// </summary>
         [XmlAttribute(AttributeName = "href")]
-        public string ContentIdAsHref => "cid:" + ContentId;
+        public string ContentIdAsHref
+        {
+            get => "cid:" + ContentId;
+            set
+            {
+                if (!value.StartsWith("cid:", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new ArgumentException("Content Id must start 'cid:'.");
+                }
+                ContentId = value.Substring(4, value.Length - 4);
+            }
+        }
 
     }
 }

--- a/src/SimpleSOAPClient/Models/Xop/Include.cs
+++ b/src/SimpleSOAPClient/Models/Xop/Include.cs
@@ -1,0 +1,24 @@
+using System.Xml.Serialization;
+
+namespace SimpleSOAPClient.Models.Xop
+{
+    /// <summary>
+    /// A reference to an attachment to the SoapEnvelope; see https://www.w3.org/TR/soap12-mtom/
+    /// </summary>
+    [XmlType(Namespace = "http://www.w3.org/2004/08/xop/include")]
+    public class Include
+    {
+        /// <summary>
+        /// The Content Id of the associated attachment.
+        /// </summary>
+        [XmlIgnore]
+        public string ContentId { get; set; }
+
+        /// <summary>
+        /// Helper method to generate the href attribute when serialized to XML.
+        /// </summary>
+        [XmlAttribute(AttributeName = "href")]
+        public string ContentIdAsHref => "cid:" + ContentId;
+
+    }
+}

--- a/src/SimpleSOAPClient/SimpleSOAPClient.csproj
+++ b/src/SimpleSOAPClient/SimpleSOAPClient.csproj
@@ -60,11 +60,5 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.aspnet.webapi.client\5.2.6\lib\portable-wp8+netcore45+net45+wp81+wpa81\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/SimpleSOAPClient/SimpleSOAPClient.csproj
+++ b/src/SimpleSOAPClient/SimpleSOAPClient.csproj
@@ -43,6 +43,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net4.5'">
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
@@ -51,7 +52,18 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="5.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.aspnet.webapi.client\5.2.6\lib\portable-wp8+netcore45+net45+wp81+wpa81\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/src/SimpleSOAPClient/SoapClient.cs
+++ b/src/SimpleSOAPClient/SoapClient.cs
@@ -208,6 +208,8 @@ namespace SimpleSOAPClient
                 await HttpClient.SendAsync(beforeHttpRequestHandlersResult.Request, ct).ConfigureAwait(false);
             
             // Handle multipart responses
+            // DotNet Standard 1.1 isn't supported by the multipart library
+#if !NETSTANDARD1_1
             IDictionary<string, HttpContent> attachments = new Dictionary<string, HttpContent>();
             if (response.Content.IsMimeMultipartContent())
             {
@@ -234,6 +236,7 @@ namespace SimpleSOAPClient
                     }
                 }
             }
+#endif
             
             var handlersOrderedDesc = _handlers.OrderByDescending(e => e.Order).ToList();
             
@@ -251,7 +254,9 @@ namespace SimpleSOAPClient
             {
                 responseEnvelope = 
                     Settings.SerializationProvider.ToSoapEnvelope(responseXml);
+#if !NETSTANDARD1_1
                 responseEnvelope.Attachments = attachments;
+#endif
             }
             catch (SoapEnvelopeDeserializationException)
             {

--- a/tests/SimpleSOAPClient.Tests/MultipartResponseTests.cs
+++ b/tests/SimpleSOAPClient.Tests/MultipartResponseTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using SimpleSOAPClient.Models;
+using Xunit;
+
+namespace SimpleSOAPClient.Tests
+{
+    public class MultipartResponseTests
+    {
+        private const string AttachmentContents = "The Attachment Contents";
+        private const string AttachmentContentId = "test-content@test.com";
+
+        [Fact]
+        public async Task Test()
+        {
+            var httpMessageHandler = new TestHttpMessageHandler();
+            var httpClient = new HttpClient(httpMessageHandler);
+            var soapClient = new SoapClient(httpClient);
+
+            var result = await soapClient.SendAsync("http://test.com", "", SoapEnvelope.Prepare());
+            Assert.Equal(AttachmentContents, await result.Attachments[AttachmentContentId].ReadAsStringAsync());
+        }
+        
+        
+        private class TestHttpMessageHandler : HttpMessageHandler
+        {
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var emptyEnvelope = new SoapEnvelopeSerializationProvider().ToXmlString(SoapEnvelope.Prepare());
+                var multipartResponse = new MultipartContent("related")
+                {
+                    new StringContent(emptyEnvelope, Encoding.UTF8, "application/xop+xml"),
+                    new StringContent(AttachmentContents, Encoding.UTF8, "text/plain")
+                    {
+                        Headers = {{"Content-Id", $"<{AttachmentContentId}>"}}
+                    }
+                };
+
+                return Task.FromResult(new HttpResponseMessage
+                {
+                    Version = HttpVersion.Version11,
+                    Content = multipartResponse,
+                    StatusCode = HttpStatusCode.OK,
+                    ReasonPhrase = "OK",
+                });
+            }
+        }
+    }
+}

--- a/tests/SimpleSOAPClient.Tests/MultipartResponseTests.cs
+++ b/tests/SimpleSOAPClient.Tests/MultipartResponseTests.cs
@@ -14,7 +14,7 @@ namespace SimpleSOAPClient.Tests
         private const string AttachmentContentId = "test-content@test.com";
 
         [Fact]
-        public async Task Test()
+        public async Task TestReceiveAndDeserializeSingleAttachment()
         {
             var httpMessageHandler = new TestHttpMessageHandler();
             var httpClient = new HttpClient(httpMessageHandler);


### PR DESCRIPTION
Partially closes #43.

The `Microsoft.AspNet.WebApi.Client` library doesn't support `Dotnet Standard 1.1` so I've wrapped the affected code in processor tags; I'm not sure if this is the best approach.